### PR TITLE
fix Unable to instantiate service MyFirebaseMessagingService

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ import com.google.firebase.messaging.RemoteMessage;
 import com.webengage.sdk.android.WebEngage;
 import java.util.Map;
 
-class MyFirebaseMessagingService extends FirebaseMessagingService {
+public class MyFirebaseMessagingService extends FirebaseMessagingService {
     @Override
     public void onMessageReceived(RemoteMessage remoteMessage) {
         Map<String, String> data = remoteMessage.getData();


### PR DESCRIPTION
Issue: fix Unable to instantiate service MyFirebaseMessagingService and is not accessible from java.lang.Class<android.app.ActivityThread>

Fix: make MyFirebaseMessagingService class to public