### PR TITLE
Optimise build time by changing dependency configuration

### DIFF
--- a/lib/android/build.gradle
+++ b/lib/android/build.gradle
@@ -34,7 +34,7 @@ repositories {
 }
 
 dependencies {
-    provided 'com.facebook.react:react-native:+'
-    provided 'com.webengage:android-sdk:3.+'
+    implementation 'com.facebook.react:react-native:+'
+    compileOnly 'com.webengage:android-sdk:3.+'
 }
-  
+


### PR DESCRIPTION
`provided` is deprecated in favour of `compileOnly`
Changed react native as an `implementation` dependency to optimise the build time
For reference: https://developer.android.com/studio/build/dependencies?utm_source=android-studio#dependency_configurations