### PR TITLE
Fixed instance issue for callback listener

### DIFF
--- a/ExampleApp/package.json
+++ b/ExampleApp/package.json
@@ -11,7 +11,7 @@
     "@react-native-community/async-storage": "^1.11.0",
     "react": "16.8.6",
     "react-native": "0.60.4",
-    "react-native-webengage": "^1.2.3"
+    "react-native-webengage": "^1.2.4"
   },
   "devDependencies": {
     "@babel/core": "^7.5.0",

--- a/lib/ios/WEGWebEngageBridge.m
+++ b/lib/ios/WEGWebEngageBridge.m
@@ -17,14 +17,14 @@ int const DATE_FORMAT_LENGTH = 24;
 @implementation WEGWebEngageBridge
 RCT_EXPORT_MODULE(webengageBridge);
 
-// + (id)allocWithZone:(NSZone *)zone {
-//     static WEGWebEngageBridge *sharedInstance = nil;
-//     static dispatch_once_t onceToken;
-//     dispatch_once(&onceToken, ^{
-//         sharedInstance = [super allocWithZone:zone];
-//     });
-//     return sharedInstance;
-// }
+ + (id)allocWithZone:(NSZone *)zone {
+     static WEGWebEngageBridge *sharedInstance = nil;
+     static dispatch_once_t onceToken;
+     dispatch_once(&onceToken, ^{
+         sharedInstance = [super allocWithZone:zone];
+     });
+     return sharedInstance;
+ }
 
 - (NSURL *)sourceURLForBridge:(RCTBridge *)bridge{
     return [[RCTBundleURLProvider sharedSettings] jsBundleURLForBundleRoot:@"index" fallbackResource:nil];


### PR DESCRIPTION
The instance for bridge sometimes is uninitialized if react-native version is less than 0.60.0