### PR TITLE
fixed `new NativeEventEmitter()` was called with a non-null argument without the required `removeListeners` method.

### DIFF
--- a/lib/android/src/main/java/com/webengage/WebengageBridge.java
+++ b/lib/android/src/main/java/com/webengage/WebengageBridge.java
@@ -262,6 +262,16 @@ public class WebengageBridge extends ReactContextBaseJavaModule implements PushN
         WebEngage.get().user().logout();
     }
 
+    @ReactMethod
+    public void addListener(String eventName) {
+        // Keep: Required for RN built in Event Emitter Calls.
+    }
+
+    @ReactMethod
+    public void removeListeners(Integer count) {
+        // Keep: Required for RN built in Event Emitter Calls.
+    }
+
     private Map<String, Object> recursivelyDeconstructReadableMap(ReadableMap readableMap) {
         ReadableMapKeySetIterator iterator = readableMap.keySetIterator();
         Map<String, Object> deconstructedMap = new HashMap<>();

--- a/lib/ios/WEGWebEngageBridge.m
+++ b/lib/ios/WEGWebEngageBridge.m
@@ -216,6 +216,14 @@ RCT_EXPORT_METHOD(logout){
     [[WebEngage sharedInstance].user logout];
 }
 
+RCT_EXPORT_METHOD(addListener : (NSString *)eventName) {
+  // Keep: Required for RN built in Event Emitter Calls.
+}
+
+RCT_EXPORT_METHOD(removeListeners : (NSInteger)count) {
+  // Keep: Required for RN built in Event Emitter Calls.
+}
+
 - (NSArray<NSString *> *)supportedEvents {
     return @[@"notificationPrepared", @"notificationShown", @"notificationClicked", @"notificationDismissed", @"pushNotificationClicked",@"universalLinkClicked"];
 }


### PR DESCRIPTION
This PR fixes
`new NativeEventEmitter()` was called with a non-null argument without the required `removeListeners` method warnings.
on react-native >= 0.65 

issue [46](https://github.com/WebEngage/react-native-webengage/issues/46)