### PR TITLE
bugfix(android): remove jcenter from build.bradle

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,6 @@ buildscript {
     ...
     repositories {
         google()
-        jcenter()
     }
     dependencies {
         ...
@@ -214,13 +213,10 @@ allprojects {
     repositories {
         mavenLocal()
         google()
-        jcenter()
         ...
     }
 }
 ```
-
-**Note**: Make sure that you have google() repository is placed above jcenter().
 
 3. Add firebase messaging dependency in app-level build gradle `android/app/build.gradle` file.
 

--- a/lib/android/build.gradle
+++ b/lib/android/build.gradle
@@ -6,7 +6,6 @@ buildscript {
     repositories {
         mavenCentral()
         google()
-        jcenter()
     }
 
     dependencies {
@@ -31,7 +30,6 @@ android {
 repositories {
     mavenCentral()
     google()
-    jcenter()
 }
 
 String readVersion() {


### PR DESCRIPTION
Fix React Native 82.1 android build error

* Where:
Build file '**/node_modules/react-native-webengage/android/build.gradle' line: 9

* What went wrong:
A problem occurred evaluating project ':react-native-webengage'.
> Could not find method jcenter() for arguments [] on repository container of type org.gradle.api.internal.artifacts.dsl.DefaultRepositoryHandler.

* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Run with --scan to generate a Build Scan (Powered by Develocity).
> Get more help at https://help.gradle.org.

BUILD FAILED in 13s
error Failed to install the app. Command failed with exit code 1: ./gradlew app:installStagingDebug -PreactNativeDevServerPort=8081 FAILURE: Build failed with an exception. * Where:
Build file '**/node_modules/react-native-webengage/android/build.gradle' line: 9 * What went wrong:
A problem occurred evaluating project ':react-native-webengage'.
> Could not find method jcenter() for arguments [] on repository container of type 